### PR TITLE
Adding new default imagery layer for Slovakia

### DIFF
--- a/sources/europe/slovakia/OrtofotomozaikaSR.json
+++ b/sources/europe/slovakia/OrtofotomozaikaSR.json
@@ -8,7 +8,7 @@
   "description": "Aerial imagery for Slovakia",
   "category": "photo",
   "max_zoom": 19,
-  "best": "true",
+  "best": true,
   "country_code": "SK",
   "attribution": {
     "required": true,

--- a/sources/europe/slovakia/OrtofotomozaikaSR.json
+++ b/sources/europe/slovakia/OrtofotomozaikaSR.json
@@ -1,0 +1,19 @@
+{
+  "id": "ortofotomozaika-sr",
+  "type": "tms",
+  "locationSet": {"include": ["sk"]},
+  "country_code": "SK",
+  "name": "Ortofotomozaika SR",
+  "url": "https://ofmozaika.tiles.freemap.sk/{zoom}/{x}/{y}.jpg",
+  "description": "Aerial imagery for Slovakia",
+  "category": "photo",
+  "max_zoom": 19,
+  "best": "true",
+  "country_code": "SK",
+  "attribution": {
+    "required": true,
+    "url": "https://wiki.openstreetmap.org/wiki/WikiProject_Slovakia/Sources#Ortofotomozaika_SR_.28orthophoto_by_GK.C3.9A_and_NLC.29",
+    "text": "© GKÚ, NLC 2017-2019"
+  },
+  "icon": "https://raw.githubusercontent.com/FreemapSlovakia/freemap-v3-react/master/src/images/freemap-logo-small.png"
+}


### PR DESCRIPTION
This is a port from `https://github.com/osmlab/editor-layer-index/blob/gh-pages/sources/europe/sk/OrtofotomozaikaSR.geojson` to set this layer as default.